### PR TITLE
Fix: Cannot call method "getDefaultFractionDigits" of null

### DIFF
--- a/cartridges/app_stripe_sfra/cartridge/models/totals.js
+++ b/cartridges/app_stripe_sfra/cartridge/models/totals.js
@@ -10,10 +10,14 @@ var base = module.superModule;
  * @returns {integer} the formatted money value
  */
 function getTotalsValue(total) {
+    if (!total.available) {
+        return 0;
+    }
+
     var currentCurency = dw.util.Currency.getCurrency(total.getCurrencyCode());
     var multiplier = Math.pow(10, currentCurency.getDefaultFractionDigits());
 
-    return !total.available ? 0 : parseInt(total.value * multiplier, 10);
+    return parseInt(total.value * multiplier, 10);
 }
 
 /**


### PR DESCRIPTION
Cannot call method "getDefaultFractionDigits" of null fix. Totals.js

Refactored totals availability check to avoid calling methods of empty objects