### PR TITLE
API call merge between customers.retrieve and paymentMethods.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 23.6.0 (2024-09-05)
+* Reduced number of API calls by merging and using expand option to include customer data in the stripeService.paymentMethods.list method from stripeWallet.js -> fetchSavedPaymentInstruments()  
+
 ## 23.5.0 (2024-07-01)
 * Express Checkout for SFRA and Site Genesis
 

--- a/cartridges/bm_stripe/cartridge/scripts/services/stripeBMService.js
+++ b/cartridges/bm_stripe/cartridge/scripts/services/stripeBMService.js
@@ -134,7 +134,7 @@ function getStripeServiceDefinition(apiKey) {
                     name: 'Stripe SFCCB2C',
                     partner_id: 'pp_partner_Fs71dOwRYXhmze',
                     url: 'https://stripe.com/docs/plugins/salesforce-commerce-cloud',
-                    version: '23.5.0'
+                    version: '23.6.0'
                 }
             };
 

--- a/cartridges/int_stripe_core/cartridge/scripts/stripe/models/stripeWallet.js
+++ b/cartridges/int_stripe_core/cartridge/scripts/stripe/models/stripeWallet.js
@@ -46,15 +46,14 @@ function fetchSavedPaymentInstruments(stripeCustomerId) {
         try {
             const stripeService = require('*/cartridge/scripts/stripe/services/stripeService');
 
-            const stripeCustomer = stripeService.customers.retrieve(stripeCustomerId);
-            const defaultPaymentMethodId = stripeCustomer.invoice_settings && stripeCustomer.invoice_settings.default_payment_method;
-            const defaultSourceId = stripeCustomer.default_source;
-            const defaultCardId = defaultPaymentMethodId || defaultSourceId;
-
-            const stripePaymentInstrumentsResponse = stripeService.paymentMethods.list(stripeCustomerId, 'card');
+            const stripePaymentInstrumentsResponse = stripeService.paymentMethods.list(stripeCustomerId, 'card', ['data.customer']);
             const stripePaymentInstruments = stripePaymentInstrumentsResponse && stripePaymentInstrumentsResponse.data;
 
             if (stripePaymentInstruments && stripePaymentInstruments.length) {
+                const stripeCustomer = stripePaymentInstruments[0].customer;
+                const defaultPaymentMethodId = stripeCustomer.invoice_settings && stripeCustomer.invoice_settings.default_payment_method;
+                const defaultSourceId = stripeCustomer.default_source;
+                const defaultCardId = defaultPaymentMethodId || defaultSourceId;
                 const CustomerPaymentInstrument = require('./customerPaymentInstrument');
 
                 stripePaymentInstruments.forEach(function (stripePaymentMethod) {

--- a/cartridges/int_stripe_core/cartridge/scripts/stripe/services/stripeService.js
+++ b/cartridges/int_stripe_core/cartridge/scripts/stripe/services/stripeService.js
@@ -137,7 +137,7 @@ function getStripeServiceDefinition() {
                     name: 'Stripe SFCCB2C',
                     partner_id: 'pp_partner_Fs71dOwRYXhmze',
                     url: 'https://stripe.com/docs/plugins/salesforce-commerce-cloud',
-                    version: '23.5.0'
+                    version: '23.6.0'
                 }
             };
 
@@ -348,7 +348,7 @@ exports.paymentMethods = {
 
         return callService(requestObject);
     },
-    list: function (customerId, type) {
+    list: function (customerId, type, expandArray) {
         var requestObject = {
             endpoint: '/payment_methods',
             queryString: {
@@ -357,6 +357,10 @@ exports.paymentMethods = {
             },
             httpMethod: 'GET'
         };
+
+        if (expandArray && expandArray.length) {
+            requestObject.queryString.expand = expandArray;
+        }
 
         return callService(requestObject);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "int_stripe_sfra",
-  "version": "23.5.0",
+  "version": "23.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
stripeWallet.js
-removed the "stripeService.customers.retrieve" call 
-added a new parameter which is an Array containing expand fields to "stripeService.paymentMethods.list" 
-used the stripePaymentInstrumentsResponse to retrieve the customer data from the first payment instrument (only if the list has a length

stripeService.js
-added the new parameter "expandArray"
-checked if populated and if true added it to "requestObject.queryString.expand"