### PR TITLE
Fix BM refund/capture amount conversion for zero-decimal currencies

### DIFF
--- a/cartridges/bm_stripe/cartridge/controllers/StripeBM.js
+++ b/cartridges/bm_stripe/cartridge/controllers/StripeBM.js
@@ -225,7 +225,14 @@ server.post('HandlePaymentsRefund', function (req, res, next) {
             return next();
         }
 
-        const amount = (amountToRefund * 100);
+        const amount = stripeBmHelper.toStripeMinorUnits(amountToRefund, order.getCurrencyCode());
+        if (amount === null) {
+            res.json({
+                error: true,
+                message: Resource.msg('paymentsrefund.invalidamount', 'stripebm', null)
+            });
+            return next();
+        }
 
         /*
          * check if stripePaymentIntentID is Not empty then refund by payment_intent
@@ -324,7 +331,14 @@ server.post('HandlePaymentsCapture', function (req, res, next) {
             return next();
         }
 
-        const amount = (amountToCapture * 100);
+        const amount = stripeBmHelper.toStripeMinorUnits(amountToCapture, order.getCurrencyCode());
+        if (amount === null) {
+            res.json({
+                error: true,
+                message: Resource.msg('paymentscapture.invalidamount', 'stripebm', null)
+            });
+            return next();
+        }
 
         /*
          * check if stripePaymentIntentID is Not empty then refund by payment_intent

--- a/cartridges/bm_stripe/cartridge/scripts/helpers/stripeBmHelper.js
+++ b/cartridges/bm_stripe/cartridge/scripts/helpers/stripeBmHelper.js
@@ -15,6 +15,33 @@ exports.getApiKey = function () {
 };
 
 /**
+ * Converts a Business Manager display amount (e.g. "10.99" or "500") into the
+ * amount expressed in the currency's minor unit, as required by the Stripe API.
+ *
+ * Uses the currency's default fraction digits so zero-decimal currencies
+ * (JPY, KRW, VND, XOF, XPF) are not incorrectly multiplied by 100. Mirrors the
+ * conversion already used at checkout time in int_stripe_core.
+ *
+ * @param {string|number} displayAmount amount entered by the BM operator
+ * @param {string} currencyCode ISO currency code of the order
+ * @returns {number|null} amount in minor units, or null when the input is not a positive number
+ */
+exports.toStripeMinorUnits = function (displayAmount, currencyCode) {
+    var Currency = require('dw/util/Currency');
+
+    var numericAmount = Number(displayAmount);
+    if (isNaN(numericAmount) || numericAmount <= 0) { // eslint-disable-line no-restricted-globals
+        return null;
+    }
+
+    var currency = Currency.getCurrency(currencyCode);
+    var fractionDigits = currency ? currency.getDefaultFractionDigits() : 2;
+    var multiplier = Math.pow(10, fractionDigits);
+
+    return Math.round(numericAmount * multiplier);
+};
+
+/**
  * Get Stripe Payment Method Definitions
  *
  * @return {Array} array with Stripe payment methods definitions

--- a/cartridges/bm_stripe/cartridge/templates/resources/stripebm.properties
+++ b/cartridges/bm_stripe/cartridge/templates/resources/stripebm.properties
@@ -25,6 +25,7 @@ paymentsrefund.ordernotfound=Order with ID {0} NOT Found.
 paymentsrefund.refundsucceeded=Refund Succeeded
 paymentsrefund.refundpending=Refund Status Pending (The bank is processing this payment's refund)
 paymentsrefund.cannotrefundorder=Cannot refund order because missing payment intent id and source id
+paymentsrefund.invalidamount=Please enter a valid positive amount to refund
 
 
 paymentscapture.title=Stripe Payments Capture
@@ -35,6 +36,7 @@ paymentscapture.issuecapture=Issue Capture
 paymentscapture.capturesucceeded=Capture Succeeded
 paymentscapture.capturepending=Capture Status Pending (The bank is processing this payment's capture)
 paymentscapture.cannotcaptureorder=Cannot capture order because missing payment intent id and source id
+paymentscapture.invalidamount=Please enter a valid positive amount to capture
 
 riskscore.viewonstripe=View on Stripe Dashboard
 riskscore.riskevaluation=Risk evaluation


### PR DESCRIPTION
## Summary

The Business Manager **refund** and **capture** handlers hardcoded `* 100` when converting the operator-entered amount to Stripe minor units:

- `cartridges/bm_stripe/cartridge/controllers/StripeBM.js` — `HandlePaymentsRefund`
- `cartridges/bm_stripe/cartridge/controllers/StripeBM.js` — `HandlePaymentsCapture`

This is correct for two-decimal currencies (USD, EUR) but **wrong for Stripe zero-decimal currencies** (JPY, KRW, VND, XOF, XPF), where the display amount already equals the API minor-unit amount. The result: refund/capture amounts submitted **100× larger** than the operator intended (e.g. entering `500` for a ¥500 refund sent `50000` = ¥50,000).

Within the order total, Stripe *accepts* the inflated amount, so silent over-refunds/over-captures were possible.

## Fix

- Add a currency-aware `toStripeMinorUnits(displayAmount, currencyCode)` helper in `stripeBmHelper.js`, using `dw.util.Currency#getDefaultFractionDigits()` — the same conversion already used at checkout time in `int_stripe_core/.../checkoutHelper.js`.
- Use it in both `HandlePaymentsRefund` and `HandlePaymentsCapture` with `order.getCurrencyCode()`.
- Reject non-numeric / non-positive input with a clear BM error message (previously there was no validation — bad input produced `NaN`).

| Currency | Operator enters | Before (buggy) | After (correct) |
| --- | ---: | ---: | ---: |
| USD | 10.00 | 1000 | 1000 |
| JPY | 500 | 50000 | 500 |
| KRW | 5000 | 500000 | 5000 |

## Scope / blast radius

Contained **entirely within the `bm_stripe` cartridge**. No changes to `int_stripe_core`, checkout, webhook, or any other flow. Two-decimal currencies (USD/EUR) are unaffected — the conversion result is identical.

## Testing

- Syntax-checked both modified JS files (`node --check`).
- Style verified against the repo's `airbnb-base/legacy` ESLint config (deps not installed locally).
- **Follow-up recommended:** the BM refund/capture paths currently have no automated test coverage. Adding unit tests for `toStripeMinorUnits` (USD vs JPY/KRW) and integration coverage for the BM flows would close the gap noted in the report.

## Origin

Reported via HackerOne #3737468 (bug bounty). Triaged as an informational/financial-integrity correctness bug — not an externally exploitable security vulnerability (requires an authenticated BM operator with refund/capture permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)